### PR TITLE
Updates to make embedding easier.

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,9 +4,13 @@ import config from '../config/environment';
 
 export default Ember.Route.extend({
   model: function(){
-    var libraries = ajax('/config/libraries.json');
-    var versions = ajax('%@/versions.json'.fmt(config.projectName));
+    var libraries, versions;
     var library  = ajax('docs/index.json');
+
+    if (!config.singleLibraryEmbedded) {
+      libraries = ajax('/config/libraries.json');
+      versions = ajax('%@/versions.json'.fmt(config.projectName));
+    }
 
     return Ember.RSVP.hash({
       library: library,

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,8 +5,8 @@ import config from '../config/environment';
 export default Ember.Route.extend({
   model: function(){
     var libraries = ajax('/config/libraries.json');
-    var versions = ajax('/%@/versions.json'.fmt(config.projectName));
-    var library  = ajax('/%@/docs/index.json'.fmt(config.baseURL));
+    var versions = ajax('%@/versions.json'.fmt(config.projectName));
+    var library  = ajax('docs/index.json');
 
     return Ember.RSVP.hash({
       library: library,

--- a/app/routes/klass.js
+++ b/app/routes/klass.js
@@ -4,7 +4,7 @@ import config from '../config/environment';
 
 export default Ember.Route.extend({
   model: function(params){
-    return ajax('/%@/docs/%@.json'.fmt(config.baseURL, params.classId));
+    return ajax('docs/%@.json'.fmt(params.classId));
   },
   afterModel: function(){
     // megajank. View#willDestroyElement is scheduled after

--- a/app/routes/klass.js
+++ b/app/routes/klass.js
@@ -1,6 +1,5 @@
 import Ember from "ember";
 import ajax from "ic-ajax";
-import config from '../config/environment';
 
 export default Ember.Route.extend({
   model: function(params){

--- a/app/routes/klass/events.js
+++ b/app/routes/klass/events.js
@@ -1,10 +1,9 @@
 import Ember from "ember";
 import ajax from "ic-ajax";
-import config from '../../config/environment';
 
 export default Ember.Route.extend({
   model: function(){
     var name = this.modelFor('klass').name;
-    return ajax('/%@/docs/%@/events.json'.fmt(config.baseURL, name));
+    return ajax('docs/%@/events.json'.fmt(name));
   }
 });

--- a/app/routes/klass/methods.js
+++ b/app/routes/klass/methods.js
@@ -1,10 +1,9 @@
 import Ember from "ember";
 import ajax from "ic-ajax";
-import config from '../../config/environment';
 
 export default Ember.Route.extend({
   model: function(){
     var name = this.modelFor('klass').name;
-    return ajax('/%@/docs/%@/methods.json'.fmt(config.baseURL, name));
+    return ajax('docs/%@/methods.json'.fmt(name));
   }
 });

--- a/app/routes/klass/properties.js
+++ b/app/routes/klass/properties.js
@@ -1,10 +1,9 @@
 import Ember from "ember";
 import ajax from "ic-ajax";
-import config from '../../config/environment';
 
 export default Ember.Route.extend({
   model: function(){
     var name = this.modelFor('klass').name;
-    return ajax('/%@/docs/%@/properties.json'.fmt(config.baseURL, name));
+    return ajax('docs/%@/properties.json'.fmt(name));
   }
 });

--- a/app/routes/module.js
+++ b/app/routes/module.js
@@ -1,6 +1,5 @@
 import Ember from "ember";
 import ajax from "ic-ajax";
-import config from '../config/environment';
 
 export default Ember.Route.extend({
   model: function(params){

--- a/app/routes/module.js
+++ b/app/routes/module.js
@@ -4,7 +4,7 @@ import config from '../config/environment';
 
 export default Ember.Route.extend({
   model: function(params){
-    return ajax('/%@/docs/modules/%@.json'.fmt(config.baseURL, params.moduleId));
+    return ajax('docs/modules/%@.json'.fmt(params.moduleId));
   },
   afterModel: function(){
     // megajank. View#willDestroyElement is scheduled after

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -26,20 +26,24 @@
 <div id="content-wrapper">
   <div id="sidebar">
     <ol id="toc-list">
-      <li class="level-1">
-        <a href="#">Projects</a>
-        <ol>
-          {{#each library in model.libraries}}
-           <li class="level-3">
-              <a {{bind-attr href=library.slug}}>{{library.name}}</a>
-            </li>
-          {{/each}}
-        </ol>
-      </li>
+      {{#if model.libraries}}
+        <li class="level-1">
+          <a href="#">Projects</a>
+          <ol>
+            {{#each library in model.libraries}}
+             <li class="level-3">
+                <a {{bind-attr href=library.slug}}>{{library.name}}</a>
+              </li>
+            {{/each}}
+          </ol>
+        </li>
+      {{/if}}
 
       <li class="level-1">
         <a {{bind-attr href=githubHREF}} target="_blank"> Tag: {{rev}}</a>
-        {{evented-select content=model.versions action="versionChanged"}}
+        {{#if model.versions}}
+          {{evented-select content=model.versions action="versionChanged"}}
+        {{/if}}
       </li>
 
       <li class="level-1">

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,6 +23,10 @@ module.exports = function(environment) {
     }
   };
 
+  if (ENV.singleLibraryEmbedded) {
+    ENV.locationType = 'hash';
+  }
+
   ENV.sassOptions = {
     includePaths: [
       'bower_components/bourbon/dist/'

--- a/config/environment.js
+++ b/config/environment.js
@@ -9,6 +9,7 @@ module.exports = function(environment) {
     // e.g. v1.8.2
     // baseURL:
     locationType: 'auto',
+    singleLibraryEmbedded: !!process.env.SINGLE_LIBRARY_EMBEDDED,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
* Use relative URL for ajax requests.
* Use hash location for embedded server.
    Ideally, the URL locally is the same as that of the main
    `api.emberjs.com` site, but that requires using a history location aware
    server locally. For the initial pass on this, we should be able to simply
    serve static files which is easier with hash location.
* Add `SINGLE_LIBRARY_EMBEDDED` mode.
* Do not hard code root path.